### PR TITLE
correct the number of REP to match the number of REP definitions

### DIFF
--- a/mn_MN/mn_MN.aff
+++ b/mn_MN/mn_MN.aff
@@ -46,7 +46,7 @@ COMPOUNDRULE (nn)*[o0,o1,o2,o3]
 COMPOUNDRULE (nn)*%?
 COMPOUNDRULE (nn)*.(nn)*%?
 
-REP 3728
+REP 3729
 REP a а
 REP c с
 REP e е


### PR DESCRIPTION
From hunspell documentation:

       REP number_of_replacement_definitions
       REP what replacement

Currently, the count has an off-by-one error. Fix it, to ensure the rules are correctly parsed.